### PR TITLE
Perth and kinross org name for odbods #217

### DIFF
--- a/_datasets/perth+%26+kinross+council-air+quality+management+areas+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-air+quality+management+areas+-+perth+and+kinross.md
@@ -4,12 +4,12 @@ category:
 date_created: '2016-05-24'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: '<p>This dataset now contains revoked AQMAs.</p>
 
   <p>Site name, date designated, revocation date (where applicable) type of pollutant
   and website URL (with more information) are now mandatory attributes for this dataset.</p>'
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/air_quality_management_areas-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-car+parking+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-car+parking+-+perth+and+kinross.md
@@ -8,14 +8,14 @@ category:
 date_created: '2017-11-13'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: "<p>Most councils will keep a record of their car parks, bays and zones. Therefore\
   \ we have tried to compile these into consistent national layers.</p>\n<p>Currently,\
   \ we publish three layers:\n - Car Parks - a polygon layer\n - Parking Bays - a\
   \ polygon layer\n - Parking Zones - a polygon layer</p>\n<p>Any supplied point records\
   \ have been buffered (bays by 2m, car parks by 10m) to create a representative area,\
   \ allowing them to be incorporated in the national dataset</p>"
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/car_parking-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-community+council+boundaries+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-community+council+boundaries+-+perth+and+kinross.md
@@ -6,7 +6,7 @@ category:
 date_created: '2016-05-24'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: '<p>Community councils are required to be established by local authorities.
   They are the most local tier of statutory representation in Scotland. They bridge
   the gap between local authorities and communities and help to make public bodies
@@ -21,7 +21,7 @@ notes: '<p>Community councils are required to be established by local authoritie
   or approval for the IS to change.    </p>
 
   <p>"name", "url" and "status" are now MANDATORY fields for this dataset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           </p>'
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/community_council_boundaries-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-forestry+and+woodland+strategy+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-forestry+and+woodland+strategy+-+perth+and+kinross.md
@@ -7,7 +7,7 @@ category:
 date_created: '2019-12-11'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: "<p>These Stragegies are a requirment that has now been added into Town and\
   \ country Planning (Scotland) Act. http://www.legislation.gov.uk/asp/2019/13/part/4/crossheading/forestry-and-woodland-strategy/enacted\n\
   \ Most councils already have a FWS and these are normally accompanied by spatial\
@@ -19,7 +19,7 @@ notes: "<p>These Stragegies are a requirment that has now been added into Town a
   \ Sensitive, Unsuitable.\n Some of the councils have produced a few layers of data\
   \ for their FWS which might apply specifically to woodland planting types, e.g.\
   \ a seperate FWS layer for native woodlands or for productive woodlands.</p>"
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/forestry_and_woodland_strategy-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-green+belt+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-green+belt+-+perth+and+kinross.md
@@ -7,7 +7,7 @@ category:
 date_created: '2016-05-31'
 date_updated: '2022-12-08'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: "<p>A council development plan may designate a green belt around a city or\
   \ town to support the spatial strategy by:\n - directing development to the most\
   \ appropriate locations and supporting regeneration;\n - protecting and enhancing\
@@ -34,7 +34,7 @@ notes: "<p>A council development plan may designate a green belt around a city o
   \                                                                              \
   \                                                                              \
   \                                                  </p>"
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/green_belt-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-libraries+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-libraries+-+perth+and+kinross.md
@@ -8,7 +8,7 @@ category:
 date_created: '2017-11-13'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: '<p>Each Local Authority should have a list of libraries within their Council
   area. These may be static i.e. located in one building all of the time, or mobile
   i.e. they are in vehicles that attend a set location on a specific day at a certain
@@ -19,7 +19,7 @@ notes: '<p>Each Local Authority should have a list of libraries within their Cou
   from The Scottish Library and Information Council (https://scottishlibraries.org/)</p>
 
   <p>"UPRN" and "address" are now MANDATORY fields for this dataset.</p>'
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/libraries-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-local+landscape+areas+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-local+landscape+areas+-+perth+and+kinross.md
@@ -5,7 +5,7 @@ category:
 date_created: '2016-05-24'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: <p>PKC designated landscapes within Perth and Kinross which merit special attention,
   either because they are of particular value and warrant protection or because they
   are degraded and require active management or positive restoration, or are under
@@ -14,7 +14,7 @@ notes: <p>PKC designated landscapes within Perth and Kinross which merit special
   17th June 2015 and readopted by Perth &amp; Kinross Council in 2020. The polygons
   were digitised by Land Use Consultants, the Consultants hired to undertake the study
   to identify the LLAs.  </p>
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/local_landscape_designation-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-local+nature+reserves+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-local+nature+reserves+-+perth+and+kinross.md
@@ -4,7 +4,7 @@ category:
 date_created: '2016-05-24'
 date_updated: '2022-12-06'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: "<p>Local Nature Reserves are areas of (at least) locally important natural\
   \ heritage, designated and managed by local authorities to give people better opportunities\
   \ to learn about and enjoy nature close to where they live. They are found across\
@@ -14,7 +14,7 @@ notes: "<p>Local Nature Reserves are areas of (at least) locally important natur
   \ it from a previously produced NatureScot national dataset.</p>\n<p>Site name,\
   \ designation date, website URL (for more information) and PA code are all mandatory\
   \ attributes for this dataset now.</p>"
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/local_nature_reserves-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-paths+and+core+paths+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-paths+and+core+paths+-+perth+and+kinross.md
@@ -8,7 +8,7 @@ category:
 date_created: '2016-05-24'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: '<p>Every local authority and National Park authority (access authorities)
   in Scotland is required to draw up a plan for a system of paths (core paths) sufficient
   for the purpose of giving the public reasonable access throughout their area. </p>
@@ -25,7 +25,7 @@ notes: '<p>Every local authority and National Park authority (access authorities
   know what physical type of route they can expect. Government guidance is making
   core paths the priority for rolling out this national standardised grading system
   information, which is set out at http://www.pathsforall.org.uk/pfa/creating-paths/path-grading-system.html                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 </p>'
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/paths_and_core_paths-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-polling+districts+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-polling+districts+-+perth+and+kinross.md
@@ -7,7 +7,7 @@ category:
 date_created: '2017-01-27'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: "<p>A Polling District is a geographical subdivision of an electoral area such\
   \ as an electoral Ward within which a polling place is designated.</p>\n<p>The Representation\
   \ of the People Act 1983 places a duty on LA to divide the local authority area\
@@ -33,7 +33,7 @@ notes: "<p>A Polling District is a geographical subdivision of an electoral area
   \ as defined by the LA\n \"polling_place\" - The name and/or address of the polling\
   \ place (based on the Corporate Address Gazeteer record) related to the polling\
   \ district, as defined by the LA</p>"
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/polling_districts-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-polling+places+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-polling+places+-+perth+and+kinross.md
@@ -7,7 +7,7 @@ category:
 date_created: '2017-01-27'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: "<p>A Polling District is a geographical subdivision of an electoral area such\
   \ as an electoral Ward within which a polling place is designated.</p>\n<p>The Representation\
   \ of the People Act 1983 places a duty on LA to divide the local authority area\
@@ -32,7 +32,7 @@ notes: "<p>A Polling District is a geographical subdivision of an electoral area
   \ Corporate Address Gazeteer record of the polling place\n \"polling_place\" - The\
   \ name and/or address of the polling place (based on the Corporate Address Gazeteer\
   \ record)</p>"
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/polling_places-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-recycling+and+waste+facilities+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-recycling+and+waste+facilities+-+perth+and+kinross.md
@@ -5,7 +5,7 @@ category:
 date_created: '2017-11-14'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: '<p>Most councils will keep a record of their recycling and waste management
   facilities. Therefore we have tried to compile these into a consistent national
   layer.</p>
@@ -13,7 +13,7 @@ notes: '<p>Most councils will keep a record of their recycling and waste managem
   <p>The layer contains Recycling Places (including locations of bins and centres)
   and Waste Management Sites (including transfer centres and current/historic landfill
   sites). Both are a point layer (any provided polygons will have a centroid created).</p>'
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/recycling_and_waste_facilities-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-school+catchments+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-school+catchments+-+perth+and+kinross.md
@@ -5,7 +5,7 @@ category:
 date_created: '2016-05-24'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: "<p>Scottish councils usually divide towns and country areas into catchments\
   \ and children living in a catchment area will usually go to the same local school.\
   \ Domestic properties typically have a catchment area for each of their local:\n\
@@ -36,7 +36,7 @@ notes: "<p>Scottish councils usually divide towns and country areas into catchme
   \                                                                              \
   \                                                                              \
   \                       </p>"
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/school_catchments-pk'
 records: null
 resources:

--- a/_datasets/perth+%26+kinross+council-tree+preservation+orders+-+perth+and+kinross.md
+++ b/_datasets/perth+%26+kinross+council-tree+preservation+orders+-+perth+and+kinross.md
@@ -8,7 +8,7 @@ category:
 date_created: '2017-01-27'
 date_updated: '2022-12-01'
 license: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-maintainer: Perth and Kinross Council
+maintainer: Perth & Kinross Council
 notes: '<p><em>Whilst TPOs are a legal requirement they may not always be digitised
   accurately. Users of this data should not assume this data is totally accurate and
   should consult the specific local authority for more detail before making any decisions</em></p>
@@ -30,7 +30,7 @@ notes: '<p><em>Whilst TPOs are a legal requirement they may not always be digiti
   (planning application, LDP , supplementary guidance) and Greenspace (maintenance
   and retention of natural assets). The dataset is available for general public use,
   stakeholders or any interested party outside the Council to identify TPOs.</p>'
-organization: Perth and Kinross Council
+organization: Perth & Kinross Council
 original_dataset_link: ' https://data.spatialhub.scot/dataset/tree_preservation_orders-pk'
 records: null
 resources:

--- a/_organizations/perth_and_kinross_council.md
+++ b/_organizations/perth_and_kinross_council.md
@@ -1,7 +1,7 @@
 ---
 schema: default
-title: Perth and Kinross Council
-description: Local authority for the Perth and Kinross Council area 
+title: Perth & Kinross Council
+description: Local authority for the Perth & Kinross Council area 
 logo: 'https://upload.wikimedia.org/wikipedia/en/3/38/Perth_and_Kinross_Council_logo.svg'
 type:
 - Local authority


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail - referencing an issue number if applicable -->
Changes the organisation name for "Perth and Kinross Council" to its correct form "Perth & Kinross Council".
Also updates the existing 14 datsets to use the correct form of the name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a part fix for [issue #217 in the od-bods repo](https://github.com/OpenDataScotland/the_od_bods/issues/217)

## How Has This Been Tested?
Executed locally and all the names match up.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
